### PR TITLE
Add support for running custom commands added via CUE through the Papyrus API

### DIFF
--- a/src/C3/Hooks/Hooks.cpp
+++ b/src/C3/Hooks/Hooks.cpp
@@ -24,6 +24,11 @@ namespace C3
 		return msgs;
 	}
 
+	void Hooks::CompileAndRunPublic(RE::Script* a_script, RE::ScriptCompiler* a_compiler, RE::COMPILER_NAME a_name, RE::TESObjectREFR* a_targetRef)
+	{
+		Hooks::CompileAndRun(a_script, a_compiler, a_name, a_targetRef);
+	}
+
 	void Hooks::CompileAndRun(RE::Script* a_script, RE::ScriptCompiler* a_compiler, RE::COMPILER_NAME a_name, RE::TESObjectREFR* a_targetRef)
 	{
 		auto cmd = a_script->GetCommand();

--- a/src/C3/Hooks/Hooks.h
+++ b/src/C3/Hooks/Hooks.h
@@ -10,6 +10,7 @@ namespace C3
 		static void Install();
 		static std::vector<RE::BSFixedString> GetMessages(size_t n);
 
+		static void CompileAndRunPublic(RE::Script* a_script, RE::ScriptCompiler* a_compiler, RE::COMPILER_NAME a_name, RE::TESObjectREFR* a_targetRef);
 	private:
 		static void CompileAndRun(RE::Script* a_script, RE::ScriptCompiler* a_compiler, RE::COMPILER_NAME a_name, RE::TESObjectREFR* a_targetRef);
 		inline static REL::Relocation<decltype(CompileAndRun)> _CompileAndRun;

--- a/src/Papyrus/Functions.h
+++ b/src/Papyrus/Functions.h
@@ -19,7 +19,17 @@ namespace Papyrus::Functions
 		const auto script = scriptFactory ? scriptFactory->Create() : nullptr;
 		if (script) {
 			script->SetCommand(command);
-			script->CompileAndRun(target);
+
+			// In some (all?) cases when a custom console command is invoked through this API
+			// it fails, even though it works from the console. Testing suggests it was
+			// bypassing the hook of Script::CompileAndRun_Impl().
+			// By creating a public: wrapper around the hook implementation, and mimicing
+			// the implementation of Script::CompileAndRunPublic(TESObjectREFR* , COMPILER_NAME)
+			// we are able to achieve running even custom commands through the API.
+			RE::ScriptCompiler compiler;
+			C3::Hooks::CompileAndRunPublic(script, &compiler, RE::COMPILER_NAME::kSystemWindowCompiler, target);
+			//script->CompileAndRun(target);
+
 			delete script;
 		}
 	}


### PR DESCRIPTION
This is to address issue #2 .

Although Script::CompileAndRun_Impl() is properly hooked, as we can see by the fact custom console commands run from the console, when attempting to run them from the Papyrus API exposed through ConsoleUtil.ExecuteCommand/ConsoleUtil.ExecuteCommandTarget the execution path ends up calling Script::CompileAndRun() which *should* call our hooked _Impl, but wasn't.

This patch creates a public wrapper around the hook implementation in Hooks and reuses the same implementation as found in one of the ScriptCompileAndRun() implementations to call the hook implementation directly, bypassing any challenges to the hook on this execution path.

Tested and works on Skyrim 1.5.97. Also tested using sl_triggers to run a script that in turn ran the custom command I attached to the issue.